### PR TITLE
Add chunk-size option to enable chunked streaming mode

### DIFF
--- a/src/clj_http/lite/core.clj
+++ b/src/clj_http/lite/core.clj
@@ -47,7 +47,8 @@
    the clj-http uses ByteArrays for the bodies."
   [{:keys [request-method scheme server-name server-port uri query-string
            headers content-type character-encoding body socket-timeout
-           conn-timeout multipart debug insecure? save-request? follow-redirects] :as req}]
+           conn-timeout multipart debug insecure? save-request? follow-redirects
+           chunk-size] :as req}]
   (let [http-url (str (name scheme) "://" server-name
                       (when server-port (str ":" server-port))
                       uri
@@ -70,6 +71,8 @@
       (.setReadTimeout conn socket-timeout))
     (when conn-timeout
       (.setConnectTimeout conn conn-timeout))
+    (when chunk-size
+      (.setChunkedStreamingMode conn chunk-size))
     (.connect conn)
     (when body
       (with-open [out (.getOutputStream conn)]


### PR DESCRIPTION
We ran into an issue using clj-http-lite on Android where uploading a large file was creating an OOM error despite all the streaming that clj-http-lite and clojure.java.io are doing.  Apparently, Android tries to buffer output so that it can be retried.  In any case, setting the chunk size solves the problem, though I couldn't think of a good way of testing it.