### PR TITLE
Java 9 & 10 support

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.6.0"}
+        slingshot {:mvn/version "0.12.1"}}}

--- a/src/clj_http/lite/util.clj
+++ b/src/clj_http/lite/util.clj
@@ -27,10 +27,15 @@
   [unencoded]
   (URLEncoder/encode unencoded "UTF-8"))
 
-(defn base64-encode
+(defmacro base64-encode
   "Encode an array of bytes into a base64 encoded string."
   [unencoded]
-  (javax.xml.bind.DatatypeConverter/printBase64Binary unencoded))
+  (if (try (import 'javax.xml.bind.DatatypeConverter)
+           (catch ClassNotFoundException _))
+    `(javax.xml.bind.DatatypeConverter/printBase64Binary ~unencoded)
+    (do
+      (import 'java.util.Base64)
+      `(.encodeToString (java.util.Base64/getEncoder) ~unencoded))))
 
 (defn to-byte-array
   "Returns a byte array for the InputStream provided."


### PR DESCRIPTION
Fixes #17.

Not sure how maintained this library is but it might also make sense to disconnect it from the upstream `cli-http` to make it easier to discover other forks with activity.

Would be happy to help maintain this as well. No new features but stability/basic stuff like this PR.